### PR TITLE
fix(sync): exclude split parents, persist isSplitParent (#89)

### DIFF
--- a/apps/web/src/__tests__/lib/queries/use-kpis.test.tsx
+++ b/apps/web/src/__tests__/lib/queries/use-kpis.test.tsx
@@ -24,7 +24,12 @@ vi.mock('firebase/firestore', () => ({
 
 import { useKpis } from '@/lib/queries/use-kpis';
 
-function makeDoc(amountCents: number, isCredit: boolean, isTransfer?: boolean) {
+function makeDoc(
+  amountCents: number,
+  isCredit: boolean,
+  isTransfer?: boolean,
+  isSplitParent?: boolean,
+) {
   return {
     id: String(Math.random()),
     data: () => ({
@@ -37,6 +42,7 @@ function makeDoc(amountCents: number, isCredit: boolean, isTransfer?: boolean) {
       isCredit,
       isManual: false,
       ...(isTransfer !== undefined ? { isTransfer } : {}),
+      ...(isSplitParent !== undefined ? { isSplitParent } : {}),
     }),
   };
 }
@@ -103,6 +109,18 @@ describe('useKpis', () => {
     const { result } = renderHook(() => useKpis('2026-04'), { wrapper });
     await waitFor(() => expect(result.current.isLoading).toBe(false));
     expect(result.current.expenses).toBe(3000);
+  });
+
+  it('excludes split parents so their children are not double-counted (#89)', async () => {
+    mockGetDocs.mockResolvedValueOnce({
+      docs: [
+        makeDoc(9000, false, false, true),  // $90 split parent — excluded
+        makeDoc(4000, false),               // $40 child/normal — counted
+      ],
+    });
+    const { result } = renderHook(() => useKpis('2026-04'), { wrapper });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.expenses).toBe(4000);
   });
 
   it('treats missing isTransfer field as not-transfer (included)', async () => {

--- a/apps/web/src/lib/queries/use-kpis.ts
+++ b/apps/web/src/lib/queries/use-kpis.ts
@@ -6,6 +6,8 @@ import { firebaseDb } from '@/lib/firebase';
 import { useAuth } from '@/lib/auth/use-auth';
 import type { TransactionDoc } from '@/lib/types/firestore';
 
+const REFRESH_INTERVAL_MS = 30_000;
+
 export interface KpiResult {
   income: number;
   expenses: number;
@@ -29,6 +31,8 @@ export function useKpis(monthYear: string): KpiResult {
   const { data, isLoading, isError } = useQuery({
     queryKey: ['kpis', uid, monthYear],
     enabled: !!uid,
+    refetchInterval: REFRESH_INTERVAL_MS,
+    refetchOnWindowFocus: true,
     queryFn: async (): Promise<TransactionDoc[]> => {
       if (!uid) return [];
       const db = firebaseDb();
@@ -48,7 +52,10 @@ export function useKpis(monthYear: string): KpiResult {
   });
 
   const transactions = data ?? [];
-  const spendable = transactions.filter((t) => !t.isTransfer);
+  // Exclude transfers (non-spend) and split parents (double-count vs children). #89
+  const spendable = transactions.filter(
+    (t) => !t.isTransfer && t.isSplitParent !== true,
+  );
   const income = spendable
     .filter((t) => t.isCredit)
     .reduce((sum, t) => sum + t.amountCents, 0);

--- a/apps/web/src/lib/queries/use-transactions.ts
+++ b/apps/web/src/lib/queries/use-transactions.ts
@@ -13,6 +13,8 @@ import { firebaseDb } from '@/lib/firebase';
 import { useAuth } from '@/lib/auth/use-auth';
 import type { TransactionDoc } from '@/lib/types/firestore';
 
+const REFRESH_INTERVAL_MS = 30_000;
+
 export interface TransactionFilters {
   categoryId?: string;
   isCredit?: boolean;
@@ -27,6 +29,8 @@ export function useTransactions(filters?: TransactionFilters) {
   return useQuery({
     queryKey: ['transactions', uid, filters ?? {}],
     enabled: !!uid,
+    refetchInterval: REFRESH_INTERVAL_MS,
+    refetchOnWindowFocus: true,
     queryFn: async (): Promise<TransactionDoc[]> => {
       if (!uid) return [];
 
@@ -53,10 +57,15 @@ export function useTransactions(filters?: TransactionFilters) {
       const q = query(collection(db, 'transactions'), ...constraints);
       const snapshot = await getDocs(q);
 
-      return snapshot.docs.map((doc) => ({
-        id: doc.id,
-        ...(doc.data() as Omit<TransactionDoc, 'id'>),
-      }));
+      return snapshot.docs
+        .map((doc) => ({
+          id: doc.id,
+          ...(doc.data() as Omit<TransactionDoc, 'id'>),
+        }))
+        // Exclude split parents: their child transactions carry the real
+        // amounts/categories, so counting the parent too would double-count.
+        // Filtered client-side so legacy docs without the field still show. #89
+        .filter((txn) => txn.isSplitParent !== true);
     },
     select: (data) => data,
   });

--- a/apps/web/src/lib/types/firestore.ts
+++ b/apps/web/src/lib/types/firestore.ts
@@ -28,6 +28,7 @@ export interface TransactionDoc {
   isCredit: boolean;
   isManual: boolean;
   isTransfer?: boolean;
+  isSplitParent?: boolean;
   userAliasId: string;
 }
 

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -172,6 +172,7 @@ async function fanOutTransaction(
     isCredit: body.isCredit === true,
     isManual: body.isManual === true,
     isTransfer: body.isTransfer === true,
+    isSplitParent: body.isSplitParent === true,
     userAliasId,
     syncedAt: FieldValue.serverTimestamp(),
   });


### PR DESCRIPTION
Companion to MoneyPulse **#97** (`fix(sync): reproject transactions on mutation + canonical aliased category contract`).

The NAS app now reprojects transactions on every mutation and marks split parents with `isSplitParent`. This PR consumes that so a split parent — whose child transactions carry the real amounts/categories — is not double-counted in the web:

- `fanOutTransaction` persists `isSplitParent` on the transaction doc.
- `useKpis` and `useTransactions` exclude `isSplitParent === true` (filtered client-side so legacy docs without the field still render).

No category-contract change is needed here: category docs and transaction `categoryId` now use aliased identifiers on the NAS side (#90), and the ingest already reads `categoryId` / `parentCategoryId`.

## Test plan
- Added `use-kpis` split-parent exclusion regression.
- Web suite: **80 app / 50 functions pass**. Build green.

Merge/deploy alongside MoneyPulse #97 (the aliased `categoryId` becomes the doc key, so a re-sync/backfill repopulates category + transaction docs under the new aliases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)